### PR TITLE
Some little modifications for PicasaWebSync

### DIFF
--- a/src/App.config
+++ b/src/App.config
@@ -13,6 +13,7 @@
 		<add key="album.access.default" value="private"/>
 		<add key="album.privateAccess.hintFileName" value="picasawebsync.private"/>
 		<add key="album.publicAccess.hintFileName" value="picasawebsync.public"/>
+		<add key="album.privateAccess.folderNames" value=""/>
 		<add key="photo.resize" value="true"/>
 		<add key="photo.resize.maxSize" value="800"/>
 		<add key="video.resize" value="false"/>

--- a/src/ImageResizer.cs
+++ b/src/ImageResizer.cs
@@ -102,6 +102,13 @@ namespace PicasaWebSync
                         resizedImage = new Bitmap(originalImage, maxWidthPixels, newHeight);
                     }
                 }
+                
+                // For now I only tested Jpeg for Exif properties copy
+    			if (originalImage.RawFormat == ImageFormat.Jpeg)
+				{
+					foreach (PropertyItem originalItem in originalImage.PropertyItems)
+						resizedImage.SetPropertyItem (originalItem);
+				}
             }
             else
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -69,7 +69,8 @@ namespace PicasaWebSync
                     uploader.ResizeVideosCommand = ConfigurationManager.AppSettings["video.resize.command"];
                     uploader.AlbumNameFormat = ConfigurationManager.AppSettings["album.nameFormat"];
                     uploader.AlbumPrivateFileName = ConfigurationManager.AppSettings["album.privateAccess.hintFileName"];
-                    uploader.AlbumPrivateFolderNames = privateAccessFolderNamesConfig.Split(',');
+                    if (privateAccessFolderNamesConfig != null && privateAccessFolderNamesConfig.Length > 0)
+    					uploader.AlbumPrivateFolderNames = privateAccessFolderNamesConfig.Split(',');
                     uploader.AlbumPublicFileName = ConfigurationManager.AppSettings["album.publicAccess.hintFileName"];
                     uploader.AddOnly = commandLineArgs.Contains("-addOnly");
                     uploader.VerboseOutput = commandLineArgs.Contains("-v");


### PR DESCRIPTION
Hi,

As I already said on your website, here are some little modifications. I have some more but for now not clean enought (work only for my case) or not finished (handle better video to encode avi to flv).

I've also update to the last version of the SDK but it changes nothing so I haven't add it to my branch. 

A little note for you : the Published property of an album doesn't seems to work at all, it always resets to DateTime.Now. I should be a problem in Google's dll as it works perfectly fine in python.

Thanks for your work

Sebastien
